### PR TITLE
correctly convert array of Resolv::IPv4 or Resolv::IPv6 to array strings

### DIFF
--- a/lib/puppet/parser/functions/dns_lookup.rb
+++ b/lib/puppet/parser/functions/dns_lookup.rb
@@ -12,7 +12,7 @@ module Puppet::Parser::Functions
     arg = arguments[0]
 
     ret = if arg.is_a? Array
-      arg.collect { |e| res.getaddresses(e).to_s }.flatten
+      arg.collect { |e| res.getaddresses(e).map(&:to_s) }.flatten
     else
       res.getaddresses(arg).collect { |r| r.to_s }
     end


### PR DESCRIPTION
This PR fixes a problem with converting an array of Resolv::IPv4 to string.

Before the patch:
```
-restrict [#<Resolv::IPv4 172.23.88.254>] kod nomodify notrap nopeer noquery
-restrict [#<Resolv::IPv4 172.23.120.254>] kod nomodify notrap nopeer noquery
```

After the patch:
```
+restrict 172.23.88.254 kod nomodify notrap nopeer noquery
+restrict 172.23.120.254 kod nomodify notrap nopeer noquery
```
